### PR TITLE
Update suggested Homestead tag.

### DIFF
--- a/Homestead/readme.md
+++ b/Homestead/readme.md
@@ -25,7 +25,7 @@ Check out the [latest tagged release](https://github.com/laravel/homestead/relea
 ```shell
 $ cd ~/Code/homestead
 
-$ git checkout v6.2.2
+$ git checkout v6.5.0
 ```
 
 #### Step 3: Configure Homestead


### PR DESCRIPTION
The [6.4.0 release](https://github.com/laravel/homestead/releases/tag/v6.4.0) includes a fix for the Mongo service issue that people were running into, and I've verified the 6.5.0 release works well on my local.

cc: @weerd