### PR TITLE
Add "smart" alias to the directions.

### DIFF
--- a/Homestead/readme.md
+++ b/Homestead/readme.md
@@ -159,7 +159,11 @@ Add the following function to your `.bashrc` or `.bash_profile`:
 
 ```bash
 function homestead() {
-  ( cd ~/Code/homestead && vagrant $* )
+  DIRECTORY=$(pwd)
+  HOMESTEAD_DIRECTORY="$HOME/Code/homestead"
+  HOME_RELATIVE_DIRECTORY=${DIRECTORY/$HOME/\~}
+  DEFAULT="ssh --command \"cd $HOME_RELATIVE_DIRECTORY; bash\""
+  (cd $HOMESTEAD_DIRECTORY; eval "vagrant ${*:-$DEFAULT}")
 }
 ```
 


### PR DESCRIPTION
This allows you to type `homestead` from any project directory and automatically end up in the corresponding directory on your Vagrant box (rather than having to then type `cd ~/Code/project-directory` on the VM). This relies on a fix added in [Homestead v6.4.0](https://github.com/laravel/homestead/releases/tag/v6.4.0).