### PR TITLE
Adds documentation for Laravel commands

### DIFF
--- a/Laravel/readme.md
+++ b/Laravel/readme.md
@@ -1,0 +1,25 @@
+# Laravel
+
+We maintain several Laravel applications:
+
+* [Northstar](https://github.com/DoSomething/northstar)
+* [Rogue](https://github.com/DoSomething/rogue)
+* [Phoenix](https://github.com/DoSomething/phoenix-next)
+* [Aurora](https://github.com/DoSomething/aurora)
+* [Chompy](https://github.com/DoSomething/chompy)
+
+## Installation
+
+See [Homestead](https://github.com/DoSomething/communal-docs/tree/master/Homestead) for installing locally.
+
+## Commands
+
+When running a console command in QA or Production, run the command as a "detached" one-off dyno (via heroku run:detached) in order to see the console output in [Papertrail](https://github.com/DoSomething/communal-docs/tree/master/Monitoring).
+
+Example:
+
+```
+heroku run:detached php artisan northstar:another-backfill-command --app dosomething-northstar-qa
+```
+
+Heroku doesn't print to the logs for normal `heroku run` since they're in an interactive terminal. It's useful to see these logs to know when a command has completed (or if it timed out).

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Simply link to a specified documentation file in this repository from another Do
 
 ## Table of Contents
 
-- [Homestead](https://github.com/DoSomething/communal-docs/tree/master/Homestead)
+- [Laravel](https://github.com/DoSomething/communal-docs/tree/master/Laravel)
+    - [Homestead](https://github.com/DoSomething/communal-docs/tree/master/Homestead)
+
 - [Sixpack](https://github.com/DoSomething/communal-docs/tree/master/Sixpack)
+
 - [Automated Tests](https://github.com/DoSomething/communal-docs/tree/master/Automated%20Tests)
 
-<p align="center">©2018 DoSomething.org.</p>
+<p align="center">© DoSomething.org.</p>


### PR DESCRIPTION
This PR adds a new page for general Laravel usage, beyond just our Homestead docs - which it links to. Plagiarizes @DFurnes via [Slack thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1587487870022500?thread_ts=1587485371.022200&cid=CUQMU4Q6B)