### PR TITLE
Adds memory limit section to Laravel commands

### DIFF
--- a/Laravel/readme.md
+++ b/Laravel/readme.md
@@ -1,6 +1,6 @@
 # Laravel
 
-We maintain several Laravel applications:
+We maintain several Laravel applications, which are hosted on Heroku:
 
 * [Northstar](https://github.com/DoSomething/northstar)
 * [Rogue](https://github.com/DoSomething/rogue)
@@ -23,3 +23,17 @@ heroku run:detached php artisan northstar:another-backfill-command --app dosomet
 ```
 
 Heroku doesn't print to the logs for normal `heroku run` since they're in an interactive terminal. It's useful to see these logs to know when a command has completed (or if it timed out).
+
+### Memory Limit
+
+Speaking of timeouts, if you run into a fatal error, e.g. `Allowed memory size of 536870912 bytes exhausted` - you can use the `-d memory_limit=512M` argument to the `php` command to bump the default memory allocation (since this is running as a CLI, and so doesn't need to save any memory for other requests).
+
+```
+heroku run:detached php -d memory_limit=512M artisan northstar:another-backfill-command --app dosomething-northstar-qa
+```
+
+If that runs out of memory again, you can try using the -`-size=standard-2x` Heroku argument and `-d memory_limit=1024M` to run the command on a bigger dyno:
+
+```
+heroku run:detached php -d memory_limit=1024M artisan northstar:another-backfill-command --app dosomething-northstar-qa --size=standard-2x
+```


### PR DESCRIPTION
Continuing the page added in #31, this PR once again plagiarizes @DFurnes's [helpful Slack messages](https://dosomething.slack.com/archives/CUQMU4Q6B/p1587492909024100?thread_ts=1587485371.022200&cid=CUQMU4Q6B) to document additional parameters that may help when running console commands on Heroku.