### PR TITLE
Starts on Contributing readme

### DIFF
--- a/Contributing/readme.md
+++ b/Contributing/readme.md
@@ -1,0 +1,29 @@
+# Contributing
+
+We keep our [code open-source at DoSomething.org](https://github.com/dosomething) when possible.
+
+## Style Guide
+
+Most of our major projects use StyleCI to lint each commit to the repo.
+
+### Imports
+
+We prefer to sort import statements by ascending line length, e.g.:
+```
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+
+import Query from '../../../../Query';
+import ReferralsListItem from './ReferralsListItem';
+import SectionHeader from '../../../../utilities/SectionHeader/SectionHeader';
+
+```
+
+## Assets
+
+### SVG
+
+When adding a SVG to the codebase, be sure to it SVGs through this optimizer: https://jakearchibald.github.io/svgomg.
+
+It will help strip out a bunch of unnecessary junk that Adobe Illustrator, Sketch (insert your favorite vector program), etc add to the code. The default settings are usually just fine and you’ll usually see around like a 50% drop in file size for most SVGs!


### PR DESCRIPTION
This PR adds a skeleton for contributing guidelines, documenting our once unspoken but now spoken favorite ascending line length rule, and where that SVG optimizer is -- plagiarizing the [Slack message from @weerd](https://dosomething.slack.com/archives/C782XBKDM/p1572463145003100) that I always search for to find the URL for said optimizer.