### PR TITLE
Updating contributing docs

### DIFF
--- a/Contributing/readme.md
+++ b/Contributing/readme.md
@@ -9,6 +9,7 @@ Most of our major projects use StyleCI to lint each commit to the repo.
 ### Imports
 
 We prefer to sort import statements by ascending line length, e.g.:
+
 ```
 import React from 'react';
 import gql from 'graphql-tag';
@@ -19,9 +20,11 @@ import ReferralsListItem from './ReferralsListItem';
 import SectionHeader from '../../../../utilities/SectionHeader/SectionHeader';
 
 ```
+
 ### Line breaks
 
 We also prefer to add a new line before and/or after declaring a variable, to help with visibility:
+
 ```
 function getThings(numberOfThings) {
   const thingOne = new Thing();
@@ -29,9 +32,9 @@ function getThings(numberOfThings) {
   if (numberOfThings === 1) {
     return thingOne;
   }
-  
+
   const thingTwo = new Thing();
-  
+
   thingTwo.sing();
   // ....
 }
@@ -50,29 +53,43 @@ It will help strip out a bunch of unnecessary junk that Adobe Illustrator, Sketc
 
 ### Data attributes
 
-When writing tests, it's handy to check for the existence of specific HTML elements, but we want to avoid adding an id or class to an element if it's only used specifically for testing. For those instances, we'll use `data-test` (and if needed, `data-id`) attributes.
+When writing tests, it's handy to check for the existence of specific HTML elements, but we want to avoid adding an id or class to an element if it is only used specifically for testing.
+
+For those instances, we'll use `data-testid` attributes.
+
+In some projects, like Phoenix, we include a package called [Testing Library](https://testing-library.com/docs/dom-testing-library/api-queries#bytestid) that provides a wonderful set of helpful utilities that can be used within our Jest and Cypress tests. It specifically includes a helper method that can grab elements by a specified `data-testid`.
 
 Example component:
 
-```
-  <MyComponent>
-    {numberOfReferrals > 3 ? (
-      <div
-        data-test="additional-referrals-count"
-        className="text-center md:text-left md:pt-16"
-      >
-        {`+ ${numberOfReferrals - 3} more`}
-      </div>
-    ) : null}
-  </MyComponent>
-```
-
-Example test:
-
-```
-  it('Should display additional referrals count', () => {
-    cy.get('[data-test=additional-referrals-count]').contains('+ 2 more');
-  });
+```jsx
+<MyComponent>
+  {numberOfReferrals > 3 ? (
+    <div
+      data-testid="additional-referrals-count"
+      className="text-center md:text-left md:pt-16"
+    >
+      {`+ ${numberOfReferrals - 3} more`}
+    </div>
+  ) : null}
+</MyComponent>
 ```
 
-**Note**: We haven't been consistent about using a `data-test` attribute, there is already a mix of other attributes like `data-ref` and `data-contentful-id` instances in the Phoenix codebase besides `data-test`, that ideally should be refactored as `data-test` / `data-id`.
+Example test utilizing testing-library utility:
+
+```js
+import { screen } from "@testing-library/react";
+
+it("Should display additional referrals count", () => {
+  cy.findByTestId("additional-referrals-count").contains("+ 2 more");
+});
+```
+
+Example vanilla test:
+
+```js
+it("Should display additional referrals count", () => {
+  cy.get("[data-testid=additional-referrals-count]").contains("+ 2 more");
+});
+```
+
+**Note**: We haven't been consistent about using a `data-testid` attribute, there is already a mix of other attributes like `data-test`, `data-id`, `data-ref` and `data-contentful-id` instances in the Phoenix codebase besides `data-testid`, that ideally should be refactored as `data-testid`.

--- a/Contributing/readme.md
+++ b/Contributing/readme.md
@@ -101,9 +101,9 @@ It will help strip out a bunch of unnecessary junk that Adobe Illustrator, Sketc
 
 ### Data attributes
 
-When writing tests, it's handy to check for the existence of specific HTML elements, but we want to avoid adding an id or class to an element if it is only used specifically for testing.
+When writing tests, it is handy to check for the existence of specific HTML elements, but we want to avoid adding an id or class to an element if it is only used specifically for testing.
 
-For those instances, we'll use `data-testid` attributes.
+For those instances, we will use `data-testid` attributes.
 
 In some projects, like Phoenix, we include a package called [Testing Library](https://testing-library.com/docs/dom-testing-library/api-queries#bytestid) that provides a wonderful set of helpful utilities that can be used within our Jest and Cypress tests. It specifically includes a helper method that can grab elements by a specified `data-testid`.
 
@@ -140,4 +140,4 @@ it("Should display additional referrals count", () => {
 });
 ```
 
-**Note**: We haven't been consistent about using a `data-testid` attribute, there is already a mix of other attributes like `data-test`, `data-id`, `data-ref` and `data-contentful-id` instances in the Phoenix codebase besides `data-testid`, that ideally should be refactored as `data-testid`.
+**Note**: We haven not been consistent about using a `data-testid` attribute, there is already a mix of other attributes like `data-test`, `data-id`, `data-ref` and `data-contentful-id` instances in the Phoenix codebase besides `data-testid`, that ideally should be refactored as `data-testid`.

--- a/Contributing/readme.md
+++ b/Contributing/readme.md
@@ -10,22 +10,21 @@ Most of our major projects use StyleCI to lint each commit to the repo.
 
 We prefer to sort import statements by ascending line length, e.g.:
 
-```
-import React from 'react';
-import gql from 'graphql-tag';
-import PropTypes from 'prop-types';
+```js
+import React from "react";
+import gql from "graphql-tag";
+import PropTypes from "prop-types";
 
-import Query from '../../../../Query';
-import ReferralsListItem from './ReferralsListItem';
-import SectionHeader from '../../../../utilities/SectionHeader/SectionHeader';
-
+import Query from "../../../../Query";
+import ReferralsListItem from "./ReferralsListItem";
+import SectionHeader from "../../../../utilities/SectionHeader/SectionHeader";
 ```
 
 ### Line breaks
 
-We also prefer to add a new line before and/or after declaring a variable, to help with visibility:
+We prefer to add a new line before and/or after declaring a variable, to help with visibility:
 
-```
+```js
 function getThings(numberOfThings) {
   const thingOne = new Thing();
 
@@ -38,7 +37,56 @@ function getThings(numberOfThings) {
   thingTwo.sing();
   // ....
 }
+```
 
+We also prefer to add a new line between HTML sibling elements to help visually separate elements and make it easier to comprehend the structure:
+
+```jsx
+// ✅ The following shows proper spacing between sibling elements.
+<SomeComponent>
+  <article>
+    <header>
+      <h1>Fusce Dolor</h1>
+
+      <div>Etiam porta sem malesuada magna mollis euismod.</div>
+    </header>
+
+    <div>
+      <p>
+        Sociis natoque <strong>penatibus</strong> et magnis dis parturient
+        montes. Praesent commodo cursus magna, vel scelerisque et.
+      </p>
+
+      <p>Nulla vitae elit libero, a pharetra augue.</p>
+    </div>
+  </article>
+
+  <div>
+    <p>Sed posuere consectetur est at lobortis.</p>
+  </div>
+</SomeComponent>
+```
+
+```jsx
+// 🚫 The following shows improper spacing between sibling elements.
+<SomeComponent>
+  <article>
+    <header>
+      <h1>Fusce Dolor</h1>
+      <div>Etiam porta sem malesuada magna mollis euismod.</div>
+    </header>
+    <div>
+      <p>
+        Sociis natoque <strong>penatibus</strong> et magnis dis parturient
+        montes. Praesent commodo cursus magna, vel scelerisque et.
+      </p>
+      <p>Nulla vitae elit libero, a pharetra augue.</p>
+    </div>
+  </article>
+  <div>
+    <p>Sed posuere consectetur est at lobortis.</p>
+  </div>
+</SomeComponent>
 ```
 
 ## Assets


### PR DESCRIPTION
We are using [Testing Library](https://testing-library.com/) on Phoenix, which is a great little utility library that helps with writing better and easier to understand tests for web UIs.

This utility library comes with a helper method for querying elements called `getByTestId()` which is very helpful but requires the data label to be `data-testid`. This is very close to our current standard but not exact, so it's useful to note that we want to switch to using new standard `data-testid` for testing moving forward!

This came up in a recent ghost inspector test [fix](https://github.com/DoSomething/phoenix-next/pull/2145).

If you want to see more examples in Phoenix for this `data-testid` in use, you can check the [`Buttons/` directory](https://github.com/DoSomething/phoenix-next/tree/master/resources/assets/components/utilities/Button) and see the different button tests which currently utilize this.

I also make the recommendation that we should not use `data-id` anymore for testing purposes. The Testing Library helper method only supports `data-testid` (of course the library itself supports querying by lots of different things, but setting `data-testid` as the standard seems good to provide consistency).

I also cleaned up this contrib doc a bit and added a section on sibling element spacing ✨ 