### PR TITLE
Adds standard input example for console command

### DIFF
--- a/Laravel/readme.md
+++ b/Laravel/readme.md
@@ -37,3 +37,13 @@ If that runs out of memory again, you can try using the -`-size=standard-2x` Her
 ```
 heroku run:detached php -d memory_limit=1024M artisan northstar:another-backfill-command --app dosomething-northstar-qa --size=standard-2x
 ```
+
+### Standard Input
+
+We often provide source files for imports as standard input, to "pipe" the file into the command from your local machine -- and so we don't have to worry about hosting it somewhere on the internet. Example:
+
+```
+cat ../college-board.csv | heroku run php -d memory_limit=512M artisan rogue:groups-import --name="The College Board" --filterByLocation --app dosomething-rogue-dev --no-tty
+```
+
+The `--no-tty` flag is needed for this to run successfully (TODO: figure out / document why)

--- a/Laravel/readme.md
+++ b/Laravel/readme.md
@@ -40,7 +40,9 @@ heroku run:detached php -d memory_limit=1024M artisan northstar:another-backfill
 
 ### Standard Input
 
-We often provide source files for imports as standard input, to "pipe" the file into the command from your local machine -- and so we don't have to worry about hosting it somewhere on the internet. Example:
+We often provide source files for imports as standard input, to "pipe" the file into the command from your local machine. This way, we don't have to worry about hosting it somewhere on the internet. 
+
+Example:
 
 ```
 cat ../college-board.csv | heroku run php -d memory_limit=512M artisan rogue:groups-import --name="The College Board" --filterByLocation --app dosomething-rogue-dev --no-tty

--- a/Laravel/readme.md
+++ b/Laravel/readme.md
@@ -48,4 +48,4 @@ Example:
 cat ../college-board.csv | heroku run php -d memory_limit=512M artisan rogue:groups-import --name="The College Board" --filterByLocation --app dosomething-rogue-dev --no-tty
 ```
 
-The `--no-tty` flag is needed for this to run successfully (TODO: figure out / document why)
+The `--no-tty` flag is needed for this to run successfully (see [this comment](https://github.com/heroku/legacy-cli/issues/1409#issuecomment-243140124) for details)


### PR DESCRIPTION
This PR plagiarizes @DFurnes from https://github.com/DoSomething/rogue/pull/1095#discussion_r469560758 to add an example of providing standard input to a Laravel console command. Also documents usage of the `--no-tty` flag, which was needed to run the command successfully on Heroku (@DFurnes had found this over in https://www.pivotaltracker.com/n/projects/2328687/stories/167327823/comments/205051531) 