### PR TITLE
Add "During The Incident" and "After The Incident" sections.

### DIFF
--- a/Incidents/README.md
+++ b/Incidents/README.md
@@ -2,7 +2,7 @@ This is our "playbook" to respond to incidents, such as [PagerDuty alerts](https
 
 First of all, **take a deep breath!** :relieved: It can be stressful to get an alert, but we're all in this together. As an on-call engineer, your first job is to [investigate the alert](#first-responder-checklist) to figure out whether this is a "real" emergency or not. If it is (or you're unsure), don't hesitate to [**Escalate** the incident](#escalate-an-incident) to summon help! 
 
-During the incident, you'll [coordinate our response](#during-the-incident)
+As a first-responder, you'll coordinate our response [during the incident](#during-the-incident) and document the issue [after the incident is resolved](#after-the-incident).
 
 We've got this!
 
@@ -43,7 +43,7 @@ Alright, so we know things are a lil' wonky. Let's see if we can find out why:
 <br/>
 <br/>
 
-## Incident Response
+## During The Incident
 
 Now that you've confirmed this is a real issue, it's time to bring in some more help. [**Escalate** the incident](#escalate-an-incident) to bring in a technical lead, then [create the incident channel & notify staff](#create-the-incident-channel). This is where we'll discuss our troubleshooting efforts.
 

--- a/Incidents/README.md
+++ b/Incidents/README.md
@@ -49,9 +49,33 @@ Now that you've confirmed this is a real issue, it's time to bring in some more 
 
 As the first responder, your job is to coordinate our response – document troubleshooting steps & make sure everyone's on the same page. At this point, you may also want to bring in additional engineers with domain expertise on the failing system(s).
 
+<br/>
+<br/>
+<br/>
+<br/>
+<p align="center">
+:fire_extinguisher:
+</p>
+<br/>
+<br/>
+<br/>
+<br/>
+
 ## After The Incident
 
 After the incident is resolved, add a ticket or comment to our ['Incidents' Pivotal board](https://www.pivotaltracker.com/n/projects/2459675). Each card on this board is a "type" of problem that could cause an incident, like "Test failures due to 503 First Byte Timeout". We use this to track trends, which we'll then discuss at our Monthly Post-Mortem meeting.
+
+<br/>
+<br/>
+<br/>
+<br/>
+<p align="center">
+:ice_cube:
+</p>
+<br/>
+<br/>
+<br/>
+<br/>
 
 ## Appendix
 

--- a/Incidents/README.md
+++ b/Incidents/README.md
@@ -1,11 +1,15 @@
 This is our "playbook" to respond to incidents, such as [PagerDuty alerts](https://www.pagerduty.com).
 
-First of all, **take a deep breath!** :relieved: It can be stressful to get an alert, but we're all in this together. As a first responder, your job is to figure out whether this is a "real" emergency or not. If it is (or you're unsure), don't hesitate to [**Escalate** the incident](#escalate-an-incident) to summon help! We've got this!
+First of all, **take a deep breath!** :relieved: It can be stressful to get an alert, but we're all in this together. As an on-call engineer, your first job is to [investigate the alert](#first-responder-checklist) to figure out whether this is a "real" emergency or not. If it is (or you're unsure), don't hesitate to [**Escalate** the incident](#escalate-an-incident) to summon help! 
+
+During the incident, you'll [coordinate our response](#during-the-incident)
+
+We've got this!
 
 ### First-Responder Checklist
 
 1. If you have time to troubleshoot (via phone or computer), **Acknowledge** the incident to let others know you're on it.
-2. If the alert was triggered by an automated test failure (from [Ghost Inspector](https://ghostinspector.com) or [Runscope](https://www.runscope.com)), it will automatically retry. This might resolve the issue, in which case you're all set & no further action is necessary!
+2. If the alert was triggered by an automated test failure (from [Ghost Inspector](https://ghostinspector.com) or [Runscope](https://www.runscope.com)), it will automatically retry. This might resolve the issue, in which case you're all set & can move on to [After The Incident](#after-the-incident) steps!
 
 If this wasn't cleared up by an automatic retry, it's time to figure out the severity of the issue:
 
@@ -23,9 +27,9 @@ Alright, so we know things are a lil' wonky. Let's see if we can find out why:
     1. We might have seen this error before & left ourselves some notes. Check the troubleshooting document for this application: [Phoenix](https://dosomething.github.io/communal-docs/Incidents/Phoenix), [GraphQL](https://dosomething.github.io/communal-docs/Incidents/GraphQL), [Northstar](https://dosomething.github.io/communal-docs/Incidents/Northstar), [Rogue](https://dosomething.github.io/communal-docs/Incidents/Rogue), [Gambit](https://dosomething.github.io/communal-docs/Incidents/Gambit), [Blink](https://dosomething.github.io/communal-docs/Incidents/Blink)
     2. If you see something spooky, like network timeouts, try [restarting the application](#restarting-the-application).
 8. Does this failure relate to a recent change or deploy?
-    1. If we changed content on a campaign (such as a closed campaign or new copy) and that's causing the failure, update the test to reflect that & re-run the test. If that resolves the incident, you're all set!
+    1. If we changed content on a campaign (such as a closed campaign or new copy) and that's causing the failure, update the test to reflect that & re-run the test. If that resolves the incident, you're all set! Follow the steps in [After The Incident](#after-the-incident) to document this.
     2. If this relates to a recent deploy, try [rolling back that deploy](#rolling-back-deploys) to the previous release. We can always fix the bug when we're back in the office.
-9. If the site is still broken, [**Escalate** the incident](#escalate-an-incident) to bring in a technical lead.
+9. If the site is still broken, [**Escalate** the incident](#escalate-an-incident) to bring in a technical lead & continue to [During The Incident](#incident-response).
 
 <br/>
 <br/>
@@ -39,7 +43,19 @@ Alright, so we know things are a lil' wonky. Let's see if we can find out why:
 <br/>
 <br/>
 
-## Merge Incidents
+## Incident Response
+
+Now that you've confirmed this is a real issue, it's time to bring in some more help. [**Escalate** the incident](#escalate-an-incident) to bring in a technical lead, then [create the incident channel & notify staff](#create-the-incident-channel). This is where we'll discuss our troubleshooting efforts.
+
+As the first responder, your job is to coordinate our response – document troubleshooting steps & make sure everyone's on the same page. At this point, you may also want to bring in additional engineers with domain expertise on the failing system(s).
+
+## After The Incident
+
+After the incident is resolved, add a ticket or comment to our ['Incidents' Pivotal board](https://www.pivotaltracker.com/n/projects/2459675). Each card on this board is a "type" of problem that could cause an incident, like "Test failures due to 503 First Byte Timeout". We use this to track trends, which we'll then discuss at our Monthly Post-Mortem meeting.
+
+## Appendix
+
+#### Merge Incidents
 
 If multiple related incidents are triggered at the same time, you can merge them to consolidate all of the alerts  & incident notes in one place. The newly merged incident will be resolved when all of the alerts within it resolve.
 
@@ -47,7 +63,7 @@ If multiple related incidents are triggered at the same time, you can merge them
 
 **Note:** You can only merge incidents while they're open (frustrating!), so do this when triaging an alert!
 
-## Incident Notes
+#### Incident Notes
 
 You can leave a note on incidents, which will appear on the incident timeline:
 
@@ -57,11 +73,11 @@ It will also appear as an update in `#deploys`:
 
 <img width="624" alt="Screen Shot 2019-12-10 at 3 25 27 PM" src="https://user-images.githubusercontent.com/583202/70566139-78c25200-1b61-11ea-8b92-f6b9c878e4f6.png">
 
-## Application Logs
+#### Application Logs
 
 Our applications all publish logs to [Papertrail](https://papertrailapp.com/dashboard). You can filter by application (such as [`dosomething-phoenix`](https://my.papertrailapp.com/systems/dosomething-phoenix/events) or [`dosomething-graphql`](https://my.papertrailapp.com/systems/dosomething-graphql/events)) or by a saved search (such as [`Phoenix: Exceptions`](https://papertrailapp.com/searches/45812651) or [`GraphQL: Exceptions`](https://my.papertrailapp.com/groups/10447062/events?q=system%3Adosomething-graphql+program%3Alambda+%22Error%22)).
 
-## Error Analytics
+#### Error Analytics
 
 If a problem is happening in Phoenix, Northstar, or Rogue, check [New Relic](https://newrelic.com)'s "Error Analytics" tab to see if there are any unusual errors in the past few hours. You can click on a specific error to see a stack trace:
 
@@ -71,26 +87,28 @@ If the problem is happening in GraphQL, check Apollo Engine's [Metrics dashboard
 
 ![Screen Shot 2019-12-10 at 3 37 33 PM](https://user-images.githubusercontent.com/583202/70566973-0a7e8f00-1b63-11ea-9982-1460fa45b3e6.png)
 
-## Restarting The Application
+#### Restarting The Application
 
 Sometimes, an issue might be solved by restarting the failing service. For applications on [Heroku](https://dashboard.heroku.com), just head to the application dashboard and choose "Restart all dynos" from the "More" menu:
 
 ![Screen Shot 2019-12-10 at 3 40 10 PM](https://user-images.githubusercontent.com/583202/70567189-72cd7080-1b63-11ea-8bb7-71a031d78626.png)
 
 
-## Rolling Back Deploys
+#### Rolling Back Deploys
 
 Some problems may be due a bug in newly deployed code. If that seems like the case, the easiest solution might be to "roll back" to a previous deploy that we know was working. This is easy for applications on [Heroku](https://dashboard.heroku.com):
 
 ![Screen Shot 2019-12-10 at 3 41 26 PM](https://user-images.githubusercontent.com/583202/70567264-98f31080-1b63-11ea-92a9-38d53df7eed1.png)
 
-## Escalate an Incident
+#### Escalate an Incident
 
 You can do this by "running a play" (hidden under the "more" menu on the mobile app):
 
 <p align="center">
   <img width="708" style="border: 1px solid #eaecef" src="https://user-images.githubusercontent.com/583202/70751752-2159e880-1cff-11ea-809c-6567b180c9ed.png">
 </p>
+
+#### Create The Incident Channel
 
 Once you've done that, **create a new `#incident-####` channel** to continue to debug & monitor the incident.
 


### PR DESCRIPTION
This pull request adds "During The Incident" and "After The Incident" sections to our incident response playbook.

Here's a [direct link](https://github.com/DoSomething/communal-docs/blob/during-after-incident/Incidents/README.md) to read these on the branch (without the diff).