### PR TITLE
Add Fastly & Contentful status links in incident playbook

### DIFF
--- a/Incidents/README.md
+++ b/Incidents/README.md
@@ -21,8 +21,8 @@ If this wasn't cleared up by an automatic retry, it's time to figure out the sev
 
 Alright, so we know things are a lil' wonky. Let's see if we can find out why:
 
-6. Could this be an external issue? It may be something outside of our control. Check the status pages for our providers: [AWS Status](https://status.aws.amazon.com), [Heroku Status](https://status.heroku.com), [Apollo Status](http://status.apollographql.com), and [MongoDB Status](https://status.cloud.mongodb.com).
-    1. If one of these services are unhealthy, note it on the incident & continue down the checklist.
+6. Could this be an external issue? It may be something outside of our control. Check the status pages for our providers: [AWS Status](https://status.aws.amazon.com), [Heroku Status](https://status.heroku.com), [Apollo Status](http://status.apollographql.com), [Fastly Status](https://status.fastly.com), [Contentful Status](https://www.contentfulstatus.com) and [MongoDB Status](https://status.cloud.mongodb.com).
+   1. If one of these services are unhealthy, note it on the incident & continue down the checklist.
 7. Look at the [application logs](#application-logs) and [error analytics](#error-analytics) for this application – does anything seem unusual?
     1. We might have seen this error before & left ourselves some notes. Check the troubleshooting document for this application: [Phoenix](https://dosomething.github.io/communal-docs/Incidents/Phoenix), [GraphQL](https://dosomething.github.io/communal-docs/Incidents/GraphQL), [Northstar](https://dosomething.github.io/communal-docs/Incidents/Northstar), [Rogue](https://dosomething.github.io/communal-docs/Incidents/Rogue), [Gambit](https://dosomething.github.io/communal-docs/Incidents/Gambit), [Blink](https://dosomething.github.io/communal-docs/Incidents/Blink)
     2. If you see something spooky, like network timeouts, try [restarting the application](#restarting-the-application).

--- a/Incidents/README.md
+++ b/Incidents/README.md
@@ -1,6 +1,6 @@
 This is our "playbook" to respond to incidents, such as [PagerDuty alerts](https://www.pagerduty.com).
 
-First of all, **take a deep breath!** :relieved: It can be stressful to get an alert, but we're all in this together. As an on-call engineer, your first job is to [investigate the alert](#first-responder-checklist) to figure out whether this is a "real" emergency or not. If it is (or you're unsure), don't hesitate to [**Escalate** the incident](#escalate-an-incident) to summon help! 
+First of all, **take a deep breath!** :relieved: It can be stressful to get an alert, but we're all in this together. As an on-call engineer, your first job is to [investigate the alert](#first-responder-checklist) to figure out whether this is a "real" emergency or not. If it is (or you're unsure), don't hesitate to [**Escalate** the incident](#escalate-an-incident) to summon help!
 
 ## When you get an alert...
 
@@ -16,19 +16,19 @@ If this wasn't cleared up by an automatic retry, it's time to figure out the sev
 3. Have multiple incidents been created in different systems? If they seem at all related, [merge them](#merge-incidents).
 4. What does the alert say? Can you reproduce the problem yourself? [Leave a note](#incident-notes) on the incident in PagerDuty.
 5. Is this something that affects the "core user flow" (registering a new account, signing up for a campaign, and submitting a post)? Try re-running [this Ghost Inspector test](https://app.ghostinspector.com/tests/5c4a1efd638e692a23208132) or testing yourself via an incognito browser.
-    1. If things truly are broken, keep going down this checklist. We'll figure it out!
-    2. If not, [**Snooze** the incident](https://support.pagerduty.com/docs/editing-incidents#section-snooze-an-incident) and we can look into more on the next business day.
+   1. If things truly are broken, keep going down this checklist. We'll figure it out!
+   2. If not, [**Snooze** the incident](https://support.pagerduty.com/docs/editing-incidents#section-snooze-an-incident) and we can look into more on the next business day.
 
 Alright, so we know things are a lil' wonky. Let's see if we can find out why:
 
 6. Could this be an external issue? It may be something outside of our control. Check the status pages for our providers: [AWS Status](https://status.aws.amazon.com), [Heroku Status](https://status.heroku.com), [Apollo Status](http://status.apollographql.com), [Fastly Status](https://status.fastly.com), [Contentful Status](https://www.contentfulstatus.com) and [MongoDB Status](https://status.cloud.mongodb.com).
    1. If one of these services are unhealthy, note it on the incident & continue down the checklist.
 7. Look at the [application logs](#application-logs) and [error analytics](#error-analytics) for this application – does anything seem unusual?
-    1. We might have seen this error before & left ourselves some notes. Check the troubleshooting document for this application: [Phoenix](https://dosomething.github.io/communal-docs/Incidents/Phoenix), [GraphQL](https://dosomething.github.io/communal-docs/Incidents/GraphQL), [Northstar](https://dosomething.github.io/communal-docs/Incidents/Northstar), [Rogue](https://dosomething.github.io/communal-docs/Incidents/Rogue), [Gambit](https://dosomething.github.io/communal-docs/Incidents/Gambit), [Blink](https://dosomething.github.io/communal-docs/Incidents/Blink)
-    2. If you see something spooky, like network timeouts, try [restarting the application](#restarting-the-application).
+   1. We might have seen this error before & left ourselves some notes. Check the troubleshooting document for this application: [Phoenix](https://dosomething.github.io/communal-docs/Incidents/Phoenix), [GraphQL](https://dosomething.github.io/communal-docs/Incidents/GraphQL), [Northstar](https://dosomething.github.io/communal-docs/Incidents/Northstar), [Rogue](https://dosomething.github.io/communal-docs/Incidents/Rogue), [Gambit](https://dosomething.github.io/communal-docs/Incidents/Gambit), [Blink](https://dosomething.github.io/communal-docs/Incidents/Blink)
+   2. If you see something spooky, like network timeouts, try [restarting the application](#restarting-the-application).
 8. Does this failure relate to a recent change or deploy?
-    1. If we changed content on a campaign (such as a closed campaign or new copy) and that's causing the failure, update the test to reflect that & re-run the test. If that resolves the incident, you're all set! Follow the steps in [**After The Incident**](#after-the-incident) to document this.
-    2. If this relates to a recent deploy, try [rolling back that deploy](#rolling-back-deploys) to the previous release. We can always fix the bug when we're back in the office.
+   1. If we changed content on a campaign (such as a closed campaign or new copy) and that's causing the failure, update the test to reflect that & re-run the test. If that resolves the incident, you're all set! Follow the steps in [**After The Incident**](#after-the-incident) to document this.
+   2. If this relates to a recent deploy, try [rolling back that deploy](#rolling-back-deploys) to the previous release. We can always fix the bug when we're back in the office.
 9. If the site is still broken, it's time to bring in more help. Continue to [**During The Incident**](#incident-response), below.
 
 <br/>
@@ -81,7 +81,7 @@ After the incident is resolved, add a ticket or comment to our ['Incidents' Pivo
 
 #### Merge Incidents
 
-If multiple related incidents are triggered at the same time, you can merge them to consolidate all of the alerts  & incident notes in one place. The newly merged incident will be resolved when all of the alerts within it resolve.
+If multiple related incidents are triggered at the same time, you can merge them to consolidate all of the alerts & incident notes in one place. The newly merged incident will be resolved when all of the alerts within it resolve.
 
 ![Screen Shot 2020-05-01 at 11 19 07 AM](https://user-images.githubusercontent.com/583202/80816627-d8b3a680-8b9d-11ea-95d6-dab73711d134.png)
 
@@ -116,7 +116,6 @@ If the problem is happening in GraphQL, check Apollo Engine's [Metrics dashboard
 Sometimes, an issue might be solved by restarting the failing service. For applications on [Heroku](https://dashboard.heroku.com), just head to the application dashboard and choose "Restart all dynos" from the "More" menu:
 
 ![Screen Shot 2019-12-10 at 3 40 10 PM](https://user-images.githubusercontent.com/583202/70567189-72cd7080-1b63-11ea-8bb7-71a031d78626.png)
-
 
 #### Rolling Back Deploys
 


### PR DESCRIPTION
1. Add links to Fastly & Contentful status pages to the playbook
2. Some formatting updates that happened on save that I figure are probably good!