### PR TITLE
Suggest NFS file mount.

### DIFF
--- a/Homestead/readme.md
+++ b/Homestead/readme.md
@@ -61,6 +61,7 @@ features:
 folders:
     - map: ~/Code
       to: /home/vagrant/Code
+      type: "nfs"
 
 # Configure which Laravel applications you are running,
 # and where their "public" directory can be found. Make


### PR DESCRIPTION
I ran into some spooky issues with Vagrant's default "synced folders" implementation that seem to have be resolved by telling Homestead to [mount my code folder via NFS](https://laravel.com/docs/8.x/homestead#configuring-shared-folders) instead. This seems to be more stable (and faster!), but requires administrator credentials anytime you start or stop your Homestead box.